### PR TITLE
构建镜像并传到 ghcr.io

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,22 @@
+
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v3
+    - name: build and push 
+      run: docker build . -t "ghcr.io/${{ github.actor }}/wxcloudrun-wxcomponent" && docker push "ghcr.io/${{ github.actor }}/wxcloudrun-wxcomponent"


### PR DESCRIPTION
加入这个配置文件就可以用免费的Github Actions构建镜像并直接传到Github的Docker仓库，避免国内难以编译或者构建镜像的问题。